### PR TITLE
remove redundant error reporting when using actions feedback type

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19157,9 +19157,6 @@ class LookingGlass {
       }
       if (!report.isCorrect) {
         core.info(actionsFeedback.failure(report.error));
-        this.forceWorkflowToFail(
-          `Your solution is incorrect, check for an issue titled "${payload.title}" for more information`
-        );
       }
     }
 

--- a/lib/lookingGlass.js
+++ b/lib/lookingGlass.js
@@ -65,9 +65,6 @@ class LookingGlass {
       }
       if (!report.isCorrect) {
         core.info(actionsFeedback.failure(report.error));
-        this.forceWorkflowToFail(
-          `Your solution is incorrect, check for an issue titled "${payload.title}" for more information`
-        );
       }
     }
 


### PR DESCRIPTION
Test was completed on a separate repo.  See screenshot below:

**before:**

![image](https://user-images.githubusercontent.com/38021615/117706081-b6c20c00-b181-11eb-9102-548b8fcbef11.png)

**after:**

![image](https://user-images.githubusercontent.com/38021615/117706106-c17ca100-b181-11eb-8ea8-d8e644767b13.png)
