### PR TITLE
Send customErrors to debugger properly 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12364,7 +12364,7 @@ async function run() {
       error.name === "ServiceError" ||
       error.name === "DisplayTypeError"
     ) {
-      core.debug(JSON.stringify(error));
+      core.debug(JSON.stringify({ name: error.name, message: error.message }));
       core.setFailed(error.userMessage);
       return;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -12366,6 +12366,7 @@ async function run() {
     ) {
       core.debug(JSON.stringify(error));
       core.setFailed(error.userMessage);
+      return;
     }
 
     core.setFailed(error);

--- a/main.js
+++ b/main.js
@@ -55,7 +55,7 @@ async function run() {
       error.name === "ServiceError" ||
       error.name === "DisplayTypeError"
     ) {
-      core.debug(JSON.stringify(error));
+      core.debug(JSON.stringify({ name: error.name, message: error.message }));
       core.setFailed(error.userMessage);
       return;
     }

--- a/main.js
+++ b/main.js
@@ -57,6 +57,7 @@ async function run() {
     ) {
       core.debug(JSON.stringify(error));
       core.setFailed(error.userMessage);
+      return;
     }
 
     core.setFailed(error);


### PR DESCRIPTION
This pull addresses unexpected feedback being displayed to the learner when they perform an action and something breaks that isn't related to their action.  Example, improper workflow syntax which breaks at the Actions level, not the grading level.

This addresses issues found with [valueErrors here](https://github.com/githubtraining/lab-scheduled-events/issues/12) and [schemaErrors here](#24 )

This commit also closes these issues.  To test change `grading.yml` to point to `githubtraining/looking-glass-action@fix-value-error-handling' and make sure `ACTIONS_STEP_DEBUGGER` is set as a repo secret to see the error obscured from the learner but displayed for the developer/author