### PR TITLE
upgrade action to `node20`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
 
 runs:
-  using: "node12"
+  using: "node20"
   main: "dist/index.js"
 
 branding:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "looking-glass-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looking-glass-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "provides feedback to learners based on the outcome of their validation lab grader workflow",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Following the [deprecation of node12](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/), I propose to upgrade the action directly to `node20`.